### PR TITLE
Update configure.ac to not use AC_TRY_COMPILE

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -456,13 +456,12 @@ AC_CACHE_VAL([ac_cv_mkdir_takes_one_arg],
     [AC_CHECK_FUNCS([mkdir _mkdir])
         AC_CACHE_CHECK([whether mkdir takes one argument],
                        [ac_cv_mkdir_takes_one_arg],
-    [AC_TRY_COMPILE([
+    [AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #include <sys/stat.h>
 #if HAVE_UNISTD_H
 #  include <unistd.h>
 #endif
-        ], [mkdir (".");],
-        [ac_cv_mkdir_takes_one_arg=yes], [ac_cv_mkdir_takes_one_arg=no])])])
+        ]], [[mkdir (".");]])],[ac_cv_mkdir_takes_one_arg=yes],[ac_cv_mkdir_takes_one_arg=no])])])
 
 #--------------------------------------------------------------------
 # Finally, generate the output file(s)


### PR DESCRIPTION
# 

Running autoconf...
configure.ac:465: warning: The macro `AC_TRY_COMPILE' is obsolete.
configure.ac:465: You should run autoupdate.
../../lib/autoconf/general.m4:2615: AC_TRY_COMPILE is expanded from...
../../lib/m4sugar/m4sh.m4:643: AS_IF is expanded from...
../../lib/autoconf/general.m4:2046: AC_CACHE_VAL is expanded from...
../../lib/autoconf/general.m4:2059: AC_CACHE_CHECK is expanded from...
../../lib/m4sugar/m4sh.m4:643: AS_IF is expanded from...
../../lib/autoconf/general.m4:2046: AC_CACHE_VAL is expanded from...
# configure.ac:465: the top level

This produces the same test and results, without the warning.

Signed-off-by: Bryan Hundven bryanhundven@gmail.com
