### PR TITLE
Add patches for aligned_alloc implementation

### DIFF
--- a/packages/gcc/8.1.0/0021-Hardcode-HAVE_ALIGNED_ALLOC-1-in-libstdc-v3-configur.patch
+++ b/packages/gcc/8.1.0/0021-Hardcode-HAVE_ALIGNED_ALLOC-1-in-libstdc-v3-configur.patch
@@ -1,0 +1,59 @@
+From 6c5095b0c956bc0d16a134370c8ec0d5dfba2ee2 Mon Sep 17 00:00:00 2001
+From: Nehal J Wani <nehaljw.kkd1@gmail.com>
+Date: Tue, 12 Jun 2018 05:26:24 +0000
+Subject: [PATCH] Hardcode HAVE_ALIGNED_ALLOC=1 in libstdc++-v3/configure
+
+---
+ libstdc++-v3/configure | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)
+
+diff --git a/libstdc++-v3/configure b/libstdc++-v3/configure
+index ba094be6f..5a16ce7c7 100755
+--- a/libstdc++-v3/configure
++++ b/libstdc++-v3/configure
+@@ -28130,6 +28130,11 @@ _ACEOF
+ fi
+ done
+ 
++# The check above works only if aligned_alloc is present as a symbol in libc.so
++# Since we provide a header only implementation, override the value here
++cat >>confdefs.h <<_ACEOF
++#define `$as_echo "HAVE_aligned_alloc" | $as_tr_cpp` 1
++_ACEOF
+ 
+   # For iconv support.
+ 
+@@ -53362,6 +53367,9 @@ _ACEOF
+ fi
+ done
+ 
++cat >>confdefs.h <<_ACEOF
++#define `$as_echo "HAVE_aligned_alloc" | $as_tr_cpp` 1
++_ACEOF
+     ;;
+ 
+   *-fuchsia*)
+@@ -59995,6 +60003,9 @@ done
+ 
+ 
+ 
++cat >>confdefs.h <<_ACEOF
++#define `$as_echo "HAVE_aligned_alloc" | $as_tr_cpp` 1
++_ACEOF
+ 
+ 
+ 
+@@ -66125,6 +66136,10 @@ _ACEOF
+ fi
+ done
+ 
++cat >>confdefs.h <<_ACEOF
++#define `$as_echo "HAVE_aligned_alloc" | $as_tr_cpp` 1
++_ACEOF
++
+     ;;
+   *-netbsd*)
+     SECTION_FLAGS='-ffunction-sections -fdata-sections'
+-- 
+2.17.0
+

--- a/packages/glibc/2.12.2/0013-Implement-aligned_alloc-using-posix_memaligned.patch
+++ b/packages/glibc/2.12.2/0013-Implement-aligned_alloc-using-posix_memaligned.patch
@@ -1,0 +1,34 @@
+From 28c5a93f4afd4e179efd2235eaebe1d8f0c12774 Mon Sep 17 00:00:00 2001
+From: Nehal J Wani <nehaljw.kkd1@gmail.com>
+Date: Mon, 11 Jun 2018 19:57:24 +0000
+Subject: [PATCH] Implement aligned_alloc using posix_memaligned
+
+---
+ stdlib/stdlib.h | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/stdlib/stdlib.h b/stdlib/stdlib.h
+index d1f3841f1b..051495db85 100644
+--- a/stdlib/stdlib.h
++++ b/stdlib/stdlib.h
+@@ -507,6 +507,17 @@ extern void *valloc (size_t __size) __THROW __attribute_malloc__ __wur;
+ /* Allocate memory of SIZE bytes with an alignment of ALIGNMENT.  */
+ extern int posix_memalign (void **__memptr, size_t __alignment, size_t __size)
+      __THROW __nonnull ((1)) __wur;
++static inline void* aligned_alloc (size_t al, size_t sz)
++{
++  void *ptr = NULL;
++  // The value of alignment shall be a power of two multiple of sizeof(void *).
++  if (al < sizeof(void*))
++    al = sizeof(void*);
++  int ret = posix_memalign (&ptr, al, sz);
++  if (ret == 0)
++    return ptr;
++  return NULL;
++}
+ #endif
+ 
+ __BEGIN_NAMESPACE_STD
+-- 
+2.17.0
+


### PR DESCRIPTION
- Add implementation in glibc headers using posix_memaligned
- Fool libstdc++ build into thinking that aligned_alloc is available